### PR TITLE
[N01] Use an enum to define the revocability of the contract to check non-set state

### DIFF
--- a/contracts/GraphTokenLockManager.sol
+++ b/contracts/GraphTokenLockManager.sol
@@ -48,7 +48,7 @@ contract GraphTokenLockManager is MinimalProxyFactory, IGraphTokenLockManager {
         uint256 endTime,
         uint256 periods,
         uint256 releaseStartTime,
-        bool revocable
+        IGraphTokenLock.Revocability revocable
     );
 
     event TokensDeposited(address indexed sender, uint256 amount);
@@ -99,11 +99,11 @@ contract GraphTokenLockManager is MinimalProxyFactory, IGraphTokenLockManager {
         uint256 _endTime,
         uint256 _periods,
         uint256 _releaseStartTime,
-        bool _revocable
+        IGraphTokenLock.Revocability _revocable
     ) external override onlyOwner {
         // Create contract using a minimal proxy and call initializer
         bytes memory initializer = abi.encodeWithSignature(
-            "initialize(address,address,address,address,uint256,uint256,uint256,uint256,uint256,bool)",
+            "initialize(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint8)",
             address(this),
             _owner,
             _beneficiary,

--- a/contracts/GraphTokenLockWallet.sol
+++ b/contracts/GraphTokenLockWallet.sol
@@ -50,7 +50,7 @@ contract GraphTokenLockWallet is GraphTokenLock {
         uint256,
         uint256,
         uint256,
-        bool
+        Revocability
     ) public override {
         revert("Must initialize with a manager parameter");
     }
@@ -66,7 +66,7 @@ contract GraphTokenLockWallet is GraphTokenLock {
         uint256 _endTime,
         uint256 _periods,
         uint256 _releaseStartTime,
-        bool _revocable
+        Revocability _revocable
     ) external {
         super.initialize(
             _owner,

--- a/contracts/IGraphTokenLock.sol
+++ b/contracts/IGraphTokenLock.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.3;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IGraphTokenLock {
+    enum Revocability { NotSet, Enabled, Disabled }
+
+    function initialize(
+        address _owner,
+        address _beneficiary,
+        address _token,
+        uint256 _managedAmount,
+        uint256 _startTime,
+        uint256 _endTime,
+        uint256 _periods,
+        uint256 _releaseStartTime,
+        Revocability _revocable
+    ) external;
+
+    // -- Balances --
+
+    function currentBalance() external view returns (uint256);
+
+    // -- Time & Periods --
+
+    function currentTime() external view returns (uint256);
+
+    function duration() external view returns (uint256);
+
+    function sinceStartTime() external view returns (uint256);
+
+    function amountPerPeriod() external view returns (uint256);
+
+    function periodDuration() external view returns (uint256);
+
+    function currentPeriod() external view returns (uint256);
+
+    function passedPeriods() external view returns (uint256);
+
+    // -- Locking & Release Schedule --
+
+    function availableAmount() external view returns (uint256);
+
+    function vestedAmount() external view returns (uint256);
+
+    function releasableAmount() external view returns (uint256);
+
+    function totalOutstandingAmount() external view returns (uint256);
+
+    function surplusAmount() external view returns (uint256);
+
+    // -- Value Transfer --
+
+    function release() external;
+
+    function withdrawSurplus(uint256 _amount) external;
+
+    function revoke() external;
+}

--- a/contracts/IGraphTokenLockManager.sol
+++ b/contracts/IGraphTokenLockManager.sol
@@ -5,6 +5,8 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import "./IGraphTokenLock.sol";
+
 interface IGraphTokenLockManager {
     // -- Factory --
 
@@ -18,7 +20,7 @@ interface IGraphTokenLockManager {
         uint256 _endTime,
         uint256 _periods,
         uint256 _releaseStartTime,
-        bool _revocable
+        IGraphTokenLock.Revocability _revocable
     ) external;
 
     // -- Funds Management --

--- a/test/config.ts
+++ b/test/config.ts
@@ -2,11 +2,17 @@ import { BigNumber, Contract } from 'ethers'
 
 import { Account } from './network'
 
+export enum Revocability {
+  NotSet,
+  Enabled,
+  Disabled,
+}
+
 export interface TokenLockSchedule {
   startTime: number
   endTime: number
   periods: number
-  revocable: boolean
+  revocable: Revocability
   releaseStartTime: number
 }
 export interface TokenLockParameters {
@@ -17,7 +23,7 @@ export interface TokenLockParameters {
   startTime: number
   endTime: number
   periods: number
-  revocable: boolean
+  revocable: Revocability
   releaseStartTime: number
 }
 
@@ -48,7 +54,7 @@ const createSchedule = (
   startMonths: number,
   durationMonths: number,
   periods: number,
-  revocable: boolean,
+  revocable: Revocability,
   releaseStartTime = 0,
 ) => {
   return {
@@ -61,11 +67,11 @@ const createSchedule = (
 
 export const createScheduleScenarios = (): Array<TokenLockSchedule> => {
   return [
-    createSchedule(0, 6, 1, false), // 6m lock-up + full release + fully vested
-    createSchedule(0, 12, 1, false), // 12m lock-up + full release  + fully vested
-    createSchedule(12, 12, 12, false), // 12m lock-up + 1/12 releases  + fully vested
-    createSchedule(0, 12, 12, false), // no-lockup + 1/12 releases  + fully vested
-    createSchedule(-12, 48, 48, true), // 1/48 releases + vested + past start + start time override
+    createSchedule(0, 6, 1, Revocability.Disabled), // 6m lock-up + full release + fully vested
+    createSchedule(0, 12, 1, Revocability.Disabled), // 12m lock-up + full release  + fully vested
+    createSchedule(12, 12, 12, Revocability.Disabled), // 12m lock-up + 1/12 releases  + fully vested
+    createSchedule(0, 12, 12, Revocability.Disabled), // no-lockup + 1/12 releases  + fully vested
+    createSchedule(-12, 48, 48, Revocability.Enabled), // 1/48 releases + vested + past start + start time override
   ]
 }
 
@@ -83,7 +89,7 @@ export const defaultInitArgs = (
   }
 
   return {
-    ...createSchedule(0, 6, 1, false),
+    ...createSchedule(0, 6, 1, Revocability.Disabled),
     ...constantData,
   }
 }


### PR DESCRIPTION
### Motivation

The default false value will signal to the system that the created wallet is not revocable.

To avoid setting improper values and relying on default values for important settings in the system, and given the fact that default values are often returned by client applications if something went wrong, use an Enum type variable that treats the default value as if the variable is not being set.