### PR TITLE
[N04] Bubble up call revert reasons on the MinimalProxyFactory create functions

### DIFF
--- a/contracts/MinimalProxyFactory.sol
+++ b/contracts/MinimalProxyFactory.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.7.3;
 
+import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 
@@ -26,23 +27,23 @@ contract MinimalProxyFactory is Ownable {
      * Deploy a MinimalProxy with CREATE
      * @param _implementation Address of the proxy target implementation
      * @param _data Bytes with the initializer call
-     * @return proxy Address of the deployed MinimalProxy
+     * @return proxyAddress Address of the deployed MinimalProxy
      */
-    function _deployProxy(address _implementation, bytes memory _data) internal returns (address proxy) {
+    function _deployProxy(address _implementation, bytes memory _data) internal returns (address proxyAddress) {
         bytes20 targetBytes = bytes20(_implementation);
         assembly {
             let clone := mload(0x40)
             mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
             mstore(add(clone, 0x14), targetBytes)
             mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-            proxy := create(0, clone, 0x37)
+            proxyAddress := create(0, clone, 0x37)
         }
 
-        emit ProxyCreated(address(proxy));
+        emit ProxyCreated(proxyAddress);
 
+        // Call function with data
         if (_data.length > 0) {
-            (bool success, ) = proxy.call(_data);
-            require(success, "MinimalProxyFactory#create: CALL_FAILED");
+            Address.functionCall(proxyAddress, _data);
         }
     }
 
@@ -62,9 +63,9 @@ contract MinimalProxyFactory is Ownable {
 
         emit ProxyCreated(proxyAddress);
 
+        // Call function with data
         if (_data.length > 0) {
-            (bool success, ) = proxyAddress.call(_data);
-            require(success, "MinimalProxyFactory#create2: CALL_FAILED");
+            Address.functionCall(proxyAddress, _data);
         }
 
         return proxyAddress;

--- a/test/tokenLockWallet.test.ts
+++ b/test/tokenLockWallet.test.ts
@@ -105,12 +105,18 @@ describe('GraphTokenLockWallet', () => {
     tokenLock = await initWithArgs(initArgs)
   })
 
-  // describe('init', function () {
-  //   it('reject re-initialization', async function () {
-  //     const tx = initWithArgs(initArgs)
-  //     await expect(tx).revertedWith('Already initialized')
-  //   })
-  // })
+  describe('Init', function () {
+    it('should bubble up revert reasons on create', async function () {
+      initArgs = defaultInitArgs(deployer, beneficiary, grt, toGRT('35000000'))
+      const tx = initWithArgs({ ...initArgs, endTime: 0 })
+      await expect(tx).revertedWith('Start time > end time')
+    })
+
+    // it('reject re-initialization', async function () {
+    //   const tx = initWithArgs(initArgs)
+    //   await expect(tx).revertedWith('Already initialized')
+    // })
+  })
 
   describe('admin', function () {
     it('should set manager', async function () {
@@ -183,6 +189,12 @@ describe('GraphTokenLockWallet', () => {
       // After state
       const afterLockBalance = await grt.balanceOf(lockAsStaking.address)
       expect(afterLockBalance).eq(beforeLockBalance.sub(stakeAmount))
+    })
+
+    it('should bubble up revert reasons for forwarded calls', async function () {
+      // Force a failing call
+      const tx = lockAsStaking.connect(beneficiary.signer).stake(toGRT('0'))
+      await expect(tx).revertedWith('!tokens')
     })
 
     it('reject a function call from other than the beneficiary', async function () {


### PR DESCRIPTION
### Motivation

Both the `_deployProxy` and the `_deployProxy2` functions of the **MinimalProxyFactory** contract make use of the low-level call keyword to initialize the created contracts, which does not give the opportunity to retrieve the eventual revert reason.

### Implements

Changes the `_deployProxy2` function to use the `Address.functionCall` function to improve the understanding of the failure reasons of any of these calls instead of manually handling the call's result.

