### PR TITLE
[H01] Make _deployProxy2 internal to avoid external users to create deterministic contracts from the Manager

### DIFF
--- a/contracts/MinimalProxyFactory.sol
+++ b/contracts/MinimalProxyFactory.sol
@@ -57,7 +57,7 @@ contract MinimalProxyFactory is Ownable {
         bytes32 _salt,
         address _implementation,
         bytes memory _data
-    ) public returns (address) {
+    ) internal returns (address) {
         address proxyAddress = Create2.deploy(0, _salt, _getContractCreationCode(_implementation));
 
         emit ProxyCreated(proxyAddress);


### PR DESCRIPTION
### Motivation

In the execution of the `createTokenLockWallet` function of the **GraphTokenLockManager** contract, the `_deployProxy2` public function is being used with a salt created from the initialization values and the masterCopy implementation address.

A malicious attacker can frontrun any transaction in the mempool calling the `createTokenLockWallet` by sending a transaction calling the `_deployProxy2` function with the same exact parameters except from the `_data` parameter, which holds the information to initialize the **GraphTokenLockWallet** contract and can be set by the attacker either to null or untrusted values.

### Implements

Change `_deployProxy2` function visibility to internal so that nobody can make use of the create2 opcode from the contract's address.
