### PR TITLE
[N02] Early revert if no funds available to create a token lock

### DIFF
--- a/contracts/GraphTokenLockManager.sol
+++ b/contracts/GraphTokenLockManager.sol
@@ -101,6 +101,8 @@ contract GraphTokenLockManager is MinimalProxyFactory, IGraphTokenLockManager {
         uint256 _releaseStartTime,
         bool _revocable
     ) external override onlyOwner {
+        require(_token.balanceOf(address(this)) >= _managedAmount, "Not enough tokens to create lock");
+
         // Create contract using a minimal proxy and call initializer
         bytes memory initializer = abi.encodeWithSignature(
             "initialize(address,address,address,address,uint256,uint256,uint256,uint256,uint256,bool)",


### PR DESCRIPTION
### Motivation

In the createTokenLockWallet function of the GraphTokenLockManager contract, the new contract is being deployed without validating the conditions under which the safeTransfer call can fail.

In case the contract does not have the amount of tokens needed to fulfill the transfer, the transaction will revert after consuming a lot of gas.