### PR TITLE
Remove 2 more functions from remix abi

### DIFF
--- a/abi/TokenLockWalletABIRemix.json
+++ b/abi/TokenLockWalletABIRemix.json
@@ -132,19 +132,6 @@
     },
     {
       "inputs": [],
-      "name": "availableAmount",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
       "name": "beneficiary",
       "outputs": [
         {
@@ -415,19 +402,6 @@
         }
       ],
       "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
       "type": "function"
     },
     {


### PR DESCRIPTION
removed availableAmount because vestedAmount is almost the same, and i think it is better to explain this one to users

removed transferOwnersip. that is a manager function