### PR TITLE
feat: add curator contracts summary to ops script

### DIFF
--- a/.graphclientrc.yml
+++ b/.graphclientrc.yml
@@ -12,7 +12,8 @@ sources:
     transforms:
       - autoPagination:
           validateSchema: true
-          
+
 documents:
   - ops/queries/network.graphql
   - ops/queries/tokenLockWallets.graphql
+  - ops/queries/curators.graphql

--- a/ops/queries/curators.graphql
+++ b/ops/queries/curators.graphql
@@ -1,0 +1,25 @@
+query CuratorWallets($blockNumber: Int, $first: Int) {
+  tokenLockWallets(
+    block: { number: $blockNumber }
+    where: { periods: 16, startTime: 1608224400, endTime: 1734454800, revocable: Disabled }
+    first: $first
+    orderBy: blockNumberCreated
+  ) {
+    id
+    beneficiary
+    managedAmount
+    periods
+    startTime
+    endTime
+    revocable
+    releaseStartTime
+    vestingCliffTime
+    initHash
+    txHash
+    manager
+    tokensReleased
+    tokensWithdrawn
+    tokensRevoked
+    blockNumberCreated
+  }
+}

--- a/ops/queries/tokenLockWallets.graphql
+++ b/ops/queries/tokenLockWallets.graphql
@@ -1,9 +1,5 @@
 query TokenLockWallets($blockNumber: Int, $first: Int) {
-  tokenLockWallets (
-      block: { number: $blockNumber },
-      first: $first,
-      orderBy: id
-  ) {
+  tokenLockWallets(block: { number: $blockNumber }, first: $first, orderBy: id) {
     id
     beneficiary
     managedAmount


### PR DESCRIPTION
Adds a new command to show curator information:

```bash
tomi:/U/t/Doc/g/th/token-distribution (main) ✗ hh contracts:curators --network mainnet
Block: 15133447 / Wed Jul 13 2022

Found 1392 curator wallets.
Total managed amount: 208283331
First curator contract deployed at block 11705025
Last curator contract deployed at block 12241132
```


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>