### PR TITLE
feat(ops): add flag to output tx builder json file for wallet lock creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ bin/
 
 
 .graphclient
+
+# Ignore tx-builder files
+tx-builder-*.json
+!tx-builder-template.json

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -412,6 +412,21 @@ task('create-token-locks', 'Create token lock contracts from file')
       template.chainId = chainId
       // template.meta.createdFromSafeAddress = '0x48301Fe520f72994d32eAd72E2B6A8447873CF50'
 
+      // Send funds to the manager
+      const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)
+      const totalAmount = getTotalAmount(entries)
+      const currentBalance = await grt.balanceOf(manager.address)
+      if (currentBalance.lt(totalAmount)) {
+        const tx = await grt.populateTransaction.transfer(manager.address, totalAmount.sub(currentBalance))
+        template.transactions.push({
+          to: tokenAddress,
+          value: 0,
+          data: tx.data,
+          contractMethod: null,
+          contractInputsValues: { _dst: '' },
+        })
+      }
+
       for (const entry of entries) {
         const tx = await manager.populateTransaction.createTokenLockWallet(
           entry.owner,

--- a/ops/tx-builder-template.json
+++ b/ops/tx-builder-template.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "chainId": "5",
+  "createdAt": 1664999924896,
+  "meta": {
+    "name": "Vesting Contracts",
+    "description": "",
+    "txBuilderVersion": "1.10.0",
+    "createdFromSafeAddress": "",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xaa4f6084a39579ddecb1224904d703183c5086d1e3d7e63ba94a8b6819dd2122"
+  },
+  "transactions": [
+  ]
+}


### PR DESCRIPTION
Add a new flag `--tx-builder`. When passed, the creation script will not deploy the contracts but instead output a json file compatible with Gnosis Safe Transaction Builder (`tx-builder-<timestamp>.json`). This file can be uploaded directly by a safe owner to initiate the batch transactions proposal.

@abarmat, I tried uploading a tx batch using ABI + inputs instead of raw calldata and the Gnosis UI still shows the encoded data so I'm not including that code. On the plus side, the tenderly summary that's show if you simulate the transaction is actually pretty good to visualize what's going to happen.

### Usage

```bash
npx hardhat create-token-locks --deploy-file ops/vesting-contracts.csv --result-file ops/results.csv --network mainnet --owner-address 0x74db79268e63302d3fc69fb5a7627f7454a41732 --tx-builder
```

### Testing steps

For our goerli token lock manager:
- [x] Transfer ownership of the contract to a multisig (https://goerli.etherscan.io/tx/0x06b43c6b1365da6cf006c18dbfe5aa6b28d5d20bb131e875fe77104d82948f82)
- [x] Generate the json file
- [x] Upload the file and initiate the proposal (https://gnosis-safe.io/app/gor:0xf1135bFF22512FF2A585b8d4489426CE660f204c/transactions/multisig_0xf1135bFF22512FF2A585b8d4489426CE660f204c_0xdcd6da69b46aee0f13f4bd4883c776c3b4e870d4206fb2003654fa9c48cc940f)


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>