### PR TITLE
Add cancel lock task, allow specifying tx builder template

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,6 +16,7 @@ import 'hardhat-gas-reporter'
 // Tasks
 
 import './ops/create'
+import './ops/delete'
 import './ops/info'
 
 // Networks

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -163,6 +163,7 @@ const prettyConfigEntry = (config: TokenLockConfigEntry) => {
     Revocable: ${config.revocable}
     ReleaseCliff: ${config.releaseStartTime} (${prettyDate(config.releaseStartTime)})
     VestingCliff: ${config.vestingCliffTime} (${prettyDate(config.vestingCliffTime)})
+    Owner: ${config.owner}
     -> ContractAddress: ${config.contractAddress}
   `
 }
@@ -410,6 +411,7 @@ task('create-token-locks', 'Create token lock contracts from file')
       const totalAmount = getTotalAmount(entries)
       const currentBalance = await grt.balanceOf(manager.address)
       if (currentBalance.lt(totalAmount)) {
+        logger.log('Building manager funding transactions...')
         const remainingBalance = totalAmount.sub(currentBalance)
         // Use GRT.approve + the manager deposit function instead of GRT.transfer to be super safe
         const approveTx = await grt.populateTransaction.approve(manager.address, remainingBalance)
@@ -431,6 +433,8 @@ task('create-token-locks', 'Create token lock contracts from file')
       }
 
       for (const entry of entries) {
+        logger.log('Building tx...')
+        logger.log(prettyConfigEntry(entry))
         const tx = await manager.populateTransaction.createTokenLockWallet(
           entry.owner,
           entry.beneficiary,
@@ -446,8 +450,6 @@ task('create-token-locks', 'Create token lock contracts from file')
           to: manager.address,
           value: 0,
           data: tx.data,
-          contractMethod: null,
-          contractInputsValues: { _dst: '' },
         })
       }
 

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -1,6 +1,5 @@
 import PQueue from 'p-queue'
 import fs from 'fs'
-import path from 'path'
 import consola from 'consola'
 import inquirer from 'inquirer'
 import { utils, BigNumber, Event, ContractTransaction, ContractReceipt, Contract, ContractFactory } from 'ethers'
@@ -280,6 +279,7 @@ task('create-token-locks', 'Create token lock contracts from file')
     'txBuilder',
     'Output transaction batch in JSON format, compatible with Gnosis Safe transaction builder. Does not deploy contracts',
   )
+  .addOptionalParam('txBuilderTemplate', 'File to use as a template for the transaction builder')
   .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
     // Get contracts
     const manager = await getTokenLockManagerOrFail(hre)
@@ -403,7 +403,7 @@ task('create-token-locks', 'Create token lock contracts from file')
       // Output tx builder json
       logger.info(`Creating transaction builder JSON file...`)
       const chainId = (await hre.ethers.provider.getNetwork()).chainId.toString()
-      const txBuilder = new TxBuilder(chainId)
+      const txBuilder = new TxBuilder(chainId, taskArgs.txBuilderTemplate)
 
       // Send funds to the manager
       const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)

--- a/ops/delete.ts
+++ b/ops/delete.ts
@@ -1,0 +1,88 @@
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { prettyEnv, askConfirm, waitTransaction } from './create'
+import consola from 'consola'
+import { TxBuilder } from './tx-builder'
+
+const logger = consola.create({})
+
+const getTokenLockWalletOrFail = async (hre: HardhatRuntimeEnvironment, address: string) => {
+  const wallet = await hre.ethers.getContractAt('GraphTokenLockWallet', address)
+  try {
+    await wallet.deployed()
+  } catch (err) {
+    logger.error('GraphTokenLockWallet not deployed at', wallet.address)
+    process.exit(1)
+  }
+
+  return wallet
+}
+
+task('cancel-token-lock', 'Cancel token lock contract')
+  .addParam('contract', 'Address of the vesting contract to be cancelled')
+  .addFlag('dryRun', 'Get the deterministic contract addresses but do not deploy')
+  .addFlag(
+    'txBuilder',
+    'Output transaction batch in JSON format, compatible with Gnosis Safe transaction builder. Does not deploy contracts',
+  )
+  .addOptionalParam('txBuilderTemplate', 'File to use as a template for the transaction builder')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    // Get contracts
+    const lockWallet = await getTokenLockWalletOrFail(hre, taskArgs.contract)
+
+    // Prepare
+    logger.log(await prettyEnv(hre))
+
+    logger.info('Cancelling token lock contract...')
+    logger.log(`> GraphTokenLockWallet: ${lockWallet.address}`)
+
+    // Check lock status
+    logger.log('Veryfing lock status...')
+    const lockAccepted = await lockWallet.isAccepted()
+    if (lockAccepted) {
+      logger.error('Lock was already accepted, use revoke() to revoke the vesting schedule')
+      process.exit(1)
+    } else {
+      logger.success(`Lock not accepted yet, preparing to cancel!`)
+    }
+
+    // Nothing else to do, exit if dry run
+    if (taskArgs.dryRun) {
+      logger.info('Running in dry run mode!')
+      process.exit(0)
+    }
+
+    if (!(await askConfirm())) {
+      logger.log('Cancelled')
+      process.exit(1)
+    }
+
+    if (!taskArgs.txBuilder) {
+      const { deployer } = await hre.getNamedAccounts()
+      const lockOwner = await lockWallet.owner()
+      if (lockOwner !== deployer) {
+        logger.error('Only the owner can cancell the token lock')
+        process.exit(1)
+      }
+
+      logger.info(`Cancelling contract...`)
+      const tx = await lockWallet.cancelLock()
+      await waitTransaction(tx)
+      logger.success(`Token lock at ${lockWallet.address} was cancelled`)
+    } else {
+      logger.info(`Creating transaction builder JSON file...`)
+      const chainId = (await hre.ethers.provider.getNetwork()).chainId.toString()
+      const txBuilder = new TxBuilder(chainId, taskArgs.txBuilderTemplate)
+
+      const tx = await lockWallet.populateTransaction.cancelLock()
+      txBuilder.addTx({
+        to: lockWallet.address,
+        data: tx.data,
+        value: 0,
+      })
+
+      // Save result into json file
+      const outputFile = txBuilder.saveToFile()
+      logger.success(`Transaction saved to ${outputFile}`)
+    }
+  })

--- a/ops/tx-builder.ts
+++ b/ops/tx-builder.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+export class TxBuilder {
+  template: any
+  chainId: string
+  outputFile: string
+
+  constructor(chainId: string) {
+    this.chainId = chainId
+
+    const dateTime = new Date().getTime()
+    const templateFilename = path.join(__dirname, 'tx-builder-template.json')
+    this.outputFile = path.join(__dirname, `tx-builder-${dateTime}.json`)
+
+    this.template = JSON.parse(fs.readFileSync(templateFilename, 'utf8'))
+    this.template.createdAt = dateTime
+    this.template.chainId = chainId
+  }
+
+  addTx(tx: any) {
+    this.template.transactions.push(tx)
+  }
+
+  saveToFile() {
+    fs.writeFileSync(this.outputFile, JSON.stringify(this.template, null, 2))
+    return this.outputFile
+  }
+}

--- a/ops/tx-builder.ts
+++ b/ops/tx-builder.ts
@@ -21,7 +21,7 @@ export class TxBuilder {
   }
 
   addTx(tx: any) {
-    this.contents.transactions.push(tx)
+    this.contents.transactions.push({ ...tx, contractMethod: null, contractInputsValues: { _dst: '' } })
   }
 
   saveToFile() {

--- a/ops/tx-builder.ts
+++ b/ops/tx-builder.ts
@@ -2,28 +2,30 @@ import fs from 'fs'
 import path from 'path'
 
 export class TxBuilder {
-  template: any
-  chainId: string
+  contents: any
   outputFile: string
 
-  constructor(chainId: string) {
-    this.chainId = chainId
+  constructor(chainId: string, _template?: string) {
+    // Template file
+    const template = _template ?? 'tx-builder-template.json'
+    const templateFilename = path.join(__dirname, template)
 
+    // Output file
     const dateTime = new Date().getTime()
-    const templateFilename = path.join(__dirname, 'tx-builder-template.json')
     this.outputFile = path.join(__dirname, `tx-builder-${dateTime}.json`)
 
-    this.template = JSON.parse(fs.readFileSync(templateFilename, 'utf8'))
-    this.template.createdAt = dateTime
-    this.template.chainId = chainId
+    // Load template
+    this.contents = JSON.parse(fs.readFileSync(templateFilename, 'utf8'))
+    this.contents.createdAt = dateTime
+    this.contents.chainId = chainId
   }
 
   addTx(tx: any) {
-    this.template.transactions.push(tx)
+    this.contents.transactions.push(tx)
   }
 
   saveToFile() {
-    fs.writeFileSync(this.outputFile, JSON.stringify(this.template, null, 2))
+    fs.writeFileSync(this.outputFile, JSON.stringify(this.contents, null, 2))
     return this.outputFile
   }
 }


### PR DESCRIPTION
### Changes
- Refactor transaction builder code into a separate class/file.
- Add `cancel-token-lock` task. This will cancel a token lock if it hasn't been accepted yet.
- Add flag `--tx-builder-template` to specify a different template to use for the transaction builder json. This allows composing actions from different tasks into a single json.

Usage example for `--tx-builder-template`:

```
// Cancel an existing vesting contract. Tx builder output stored at tx-builder-1665697442567.json
npx hardhat cancel-token-lock \
   --contract 0xe743cFcdEdC961Df6c7488ae51Df0e4dbaeB34Ba \
   --network mainnet \
   --tx-builder


// Create a new vesting contract. Use JSON file from the previous step as the template.
// The JSON file output from this command will contain transactions from both previous and current tasks.
npx hardhat create-token-locks \
   --deploy-file ops/vesting-contracts.csv \
   --result-file ops/results.csv \
   --network mainnet \
   --owner-address 0x6fc78dcc8A949d1530035bD577DCB21e9787100e \ 
   --tx-builder \
   --tx-builder-template tx-builder-1665697442567.json
```