### PR TITLE
feat: allow deploying a contract multiple times

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,7 +8,7 @@
 During this process the mastecopy of the TokenLockWallet will be deployed and used in the Manager.
 
 ```
-npx hardhat deploy --tags manager --network rinkeby
+npx hardhat deploy --tags manager --network goerli
 ```
 
 ### 2. Fund the manager with the amount we need to deploy contracts
@@ -16,19 +16,19 @@ npx hardhat deploy --tags manager --network rinkeby
 The task will convert the amount passed in GRT to wei before calling the contracts.
 
 ```
-npx hardhat manager-deposit --amount <amount-in-grt> --network rinkeby
+npx hardhat manager-deposit --amount <amount-in-grt> --network goerli
 ```
 
 ### 3. Deploy a number of TokenLock contracts using the Manager
 
 ```
-npx hardhat create-token-locks --deploy-file <deploy-file.csv> --result-file <result-file.csv> --owner-address <owner-address> --network rinkeby
+npx hardhat create-token-locks --deploy-file <deploy-file.csv> --result-file <result-file.csv> --owner-address <owner-address> --network goerli
 ```
 
 ### 4. Setup the Token Manager to allow default protocol functions
 
 ```
-npx hardhat manager-setup-auth --target-address <staking-address> --network rinkeby
+npx hardhat manager-setup-auth --target-address <staking-address> --network goerli
 ```
 
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -18,6 +18,7 @@ import 'hardhat-gas-reporter'
 import './ops/create'
 import './ops/delete'
 import './ops/info'
+import './ops/manager'
 
 // Networks
 

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -60,7 +60,7 @@ const isValidAddress = (address: string) => {
   }
 }
 
-const isValidAddressOrFail = (address: string) => {
+export const isValidAddressOrFail = (address: string) => {
   if (!isValidAddress(address)) {
     process.exit(1)
   }
@@ -244,8 +244,8 @@ const populateEntries = async (
   return results
 }
 
-const getTokenLockManagerOrFail = async (hre: HardhatRuntimeEnvironment) => {
-  const deployment = await hre.deployments.get('GraphTokenLockManager')
+export const getTokenLockManagerOrFail = async (hre: HardhatRuntimeEnvironment, name: string) => {
+  const deployment = await hre.deployments.get(name)
   if (!deployment.address) {
     logger.error('GraphTokenLockManager address not found')
     process.exit(1)
@@ -275,6 +275,7 @@ task('create-token-locks', 'Create token lock contracts from file')
   .addParam('deployFile', 'File from where to read the deploy config')
   .addParam('resultFile', 'File where to save results')
   .addParam('ownerAddress', 'Owner address of token lock contracts')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
   .addFlag('dryRun', 'Get the deterministic contract addresses but do not deploy')
   .addFlag(
     'txBuilder',
@@ -283,7 +284,7 @@ task('create-token-locks', 'Create token lock contracts from file')
   .addOptionalParam('txBuilderTemplate', 'File to use as a template for the transaction builder')
   .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
     // Get contracts
-    const manager = await getTokenLockManagerOrFail(hre)
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
 
     // Prepare
     logger.log(await prettyEnv(hre))
@@ -539,132 +540,12 @@ task('create-token-locks-simple', 'Create token lock contracts from file')
     }
   })
 
-task('manager-setup-auth', 'Setup default authorized functions in the manager')
-  .addParam('targetAddress', 'Target address for function calls')
-  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
-    // Get contracts
-    const manager = await getTokenLockManagerOrFail(hre)
-
-    // Prepare
-    logger.log(await prettyEnv(hre))
-
-    // Validations
-    isValidAddressOrFail(taskArgs.targetAddress)
-
-    // Setup authorized functions
-    const signatures = [
-      'stake(uint256)',
-      'unstake(uint256)',
-      'withdraw()',
-      'delegate(address,uint256)',
-      'undelegate(address,uint256)',
-      'withdrawDelegated(address,address)',
-      'setDelegationParameters(uint32,uint32,uint32)',
-      'setOperator(address,bool)',
-    ]
-
-    logger.info('The following signatures will be authorized:')
-    logger.info(signatures)
-
-    if (await askConfirm()) {
-      // Setup authorized functions
-      logger.info('Setup authorized functions...')
-      const targets = Array(signatures.length).fill(taskArgs.targetAddress)
-      const tx1 = await manager.setAuthFunctionCallMany(signatures, targets)
-      await waitTransaction(tx1)
-      logger.success('Done!\n')
-
-      // Setup authorized token destinations
-      logger.info('Setup authorized destinations...')
-      const tx2 = await manager.addTokenDestination(taskArgs.targetAddress)
-      await waitTransaction(tx2)
-    }
-  })
-
-task('manager-deposit', 'Deposit fund into the manager')
-  .addParam('amount', 'Amount to deposit in GRT')
-  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
-    // Get contracts
-    const manager = await getTokenLockManagerOrFail(hre)
-
-    // Prepare
-    logger.log(await prettyEnv(hre))
-
-    const tokenAddress = await manager.token()
-
-    logger.info('Using:')
-    logger.log(`> GraphToken: ${tokenAddress}`)
-    logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
-    logger.log(`> GraphTokenLockManager: ${manager.address}`)
-
-    // Deposit funds
-    logger.log(`You are depositing ${taskArgs.amount} into ${manager.address}...`)
-    if (await askConfirm()) {
-      const weiAmount = parseEther(taskArgs.amount)
-
-      logger.log('Approve...')
-      const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)
-      const tx1 = await grt.approve(manager.address, weiAmount)
-      await waitTransaction(tx1)
-
-      logger.log('Deposit...')
-      const tx2 = await manager.deposit(weiAmount)
-      await waitTransaction(tx2)
-    }
-  })
-
-task('manager-withdraw', 'Withdraw fund from the manager')
-  .addParam('amount', 'Amount to deposit in GRT')
-  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
-    // Get contracts
-    const manager = await getTokenLockManagerOrFail(hre)
-
-    // Prepare
-    logger.log(await prettyEnv(hre))
-
-    const tokenAddress = await manager.token()
-
-    logger.info('Using:')
-    logger.log(`> GraphToken: ${tokenAddress}`)
-    logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
-    logger.log(`> GraphTokenLockManager: ${manager.address}`)
-
-    // Withdraw funds
-    logger.log(`You are withdrawing ${taskArgs.amount} from ${manager.address}...`)
-    if (await askConfirm()) {
-      const weiAmount = parseEther(taskArgs.amount)
-
-      logger.log('Deposit...')
-      const tx = await manager.withdraw(weiAmount)
-      await waitTransaction(tx)
-    }
-  })
-
-task('manager-balance', 'Get current manager balance').setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
-  // Get contracts
-  const manager = await getTokenLockManagerOrFail(hre)
-
-  // Prepare
-  logger.log(await prettyEnv(hre))
-
-  const tokenAddress = await manager.token()
-  const managerOwnerAddress = await manager.owner()
-
-  logger.info('Using:')
-  logger.log(`> GraphToken: ${tokenAddress}`)
-  logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
-  logger.log(`> GraphTokenLockManager: ${manager.address} owner: ${managerOwnerAddress}`)
-
-  const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)
-  const balance = await grt.balanceOf(manager.address)
-  logger.log('Current Manager balance is ', formatEther(balance))
-})
-
 task('scan-token-locks-balances', 'Check current balances of deployed contracts')
   .addParam('resultFile', 'File where to load deployed contracts')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
   .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
     // Get contracts
-    const manager = await getTokenLockManagerOrFail(hre)
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
 
     // Prepare
     logger.log(await prettyEnv(hre))

--- a/ops/manager.ts
+++ b/ops/manager.ts
@@ -1,0 +1,160 @@
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { askConfirm, getTokenLockManagerOrFail, isValidAddressOrFail, prettyEnv, waitTransaction } from './create'
+import consola from 'consola'
+import { formatEther, parseEther } from 'ethers/lib/utils'
+
+const logger = consola.create({})
+
+task('manager-setup-auth', 'Setup default authorized functions in the manager')
+  .addParam('targetAddress', 'Target address for function calls')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    // Get contracts
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
+
+    // Prepare
+    logger.log(await prettyEnv(hre))
+
+    // Validations
+    isValidAddressOrFail(taskArgs.targetAddress)
+
+    // Setup authorized functions
+    const signatures = [
+      'stake(uint256)',
+      'unstake(uint256)',
+      'withdraw()',
+      'delegate(address,uint256)',
+      'undelegate(address,uint256)',
+      'withdrawDelegated(address,address)',
+      'setDelegationParameters(uint32,uint32,uint32)',
+      'setOperator(address,bool)',
+    ]
+
+    logger.info('The following signatures will be authorized:')
+    logger.info(signatures)
+
+    if (await askConfirm()) {
+      // Setup authorized functions
+      logger.info('Setup authorized functions...')
+      const targets = Array(signatures.length).fill(taskArgs.targetAddress)
+      const tx1 = await manager.setAuthFunctionCallMany(signatures, targets)
+      await waitTransaction(tx1)
+      logger.success('Done!\n')
+
+      // Setup authorized token destinations
+      logger.info('Setup authorized destinations...')
+      const tx2 = await manager.addTokenDestination(taskArgs.targetAddress)
+      await waitTransaction(tx2)
+    }
+  })
+
+task('manager-deposit', 'Deposit fund into the manager')
+  .addParam('amount', 'Amount to deposit in GRT')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    // Get contracts
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
+
+    // Prepare
+    logger.log(await prettyEnv(hre))
+
+    const tokenAddress = await manager.token()
+
+    logger.info('Using:')
+    logger.log(`> GraphToken: ${tokenAddress}`)
+    logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
+    logger.log(`> GraphTokenLockManager: ${manager.address}`)
+
+    // Deposit funds
+    logger.log(`You are depositing ${taskArgs.amount} into ${manager.address}...`)
+    if (await askConfirm()) {
+      const weiAmount = parseEther(taskArgs.amount)
+
+      logger.log('Approve...')
+      const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)
+      const tx1 = await grt.approve(manager.address, weiAmount)
+      await waitTransaction(tx1)
+
+      logger.log('Deposit...')
+      const tx2 = await manager.deposit(weiAmount)
+      await waitTransaction(tx2)
+    }
+  })
+
+task('manager-withdraw', 'Withdraw fund from the manager')
+  .addParam('amount', 'Amount to deposit in GRT')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    // Get contracts
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
+
+    // Prepare
+    logger.log(await prettyEnv(hre))
+
+    const tokenAddress = await manager.token()
+
+    logger.info('Using:')
+    logger.log(`> GraphToken: ${tokenAddress}`)
+    logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
+    logger.log(`> GraphTokenLockManager: ${manager.address}`)
+
+    // Withdraw funds
+    logger.log(`You are withdrawing ${taskArgs.amount} from ${manager.address}...`)
+    if (await askConfirm()) {
+      const weiAmount = parseEther(taskArgs.amount)
+
+      logger.log('Deposit...')
+      const tx = await manager.withdraw(weiAmount)
+      await waitTransaction(tx)
+    }
+  })
+
+task('manager-balance', 'Get current manager balance')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    // Get contracts
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
+
+    // Prepare
+    logger.log(await prettyEnv(hre))
+
+    const tokenAddress = await manager.token()
+    const managerOwnerAddress = await manager.owner()
+
+    logger.info('Using:')
+    logger.log(`> GraphToken: ${tokenAddress}`)
+    logger.log(`> GraphTokenLockMasterCopy: ${await manager.masterCopy()}`)
+    logger.log(`> GraphTokenLockManager: ${manager.address} owner: ${managerOwnerAddress}`)
+
+    const grt = await hre.ethers.getContractAt('ERC20', tokenAddress)
+    const balance = await grt.balanceOf(manager.address)
+    logger.log('Current Manager balance is ', formatEther(balance))
+  })
+
+task('manager-transfer-ownership', 'Transfer ownership of the manager')
+  .addParam('owner', 'Address of the new owner')
+  .addParam('managerName', 'Name of the token lock manager deployment', 'GraphTokenLockManager')
+  .setAction(async (taskArgs, hre: HardhatRuntimeEnvironment) => {
+    const manager = await getTokenLockManagerOrFail(hre, taskArgs.managerName)
+
+    // Validate current owner
+    const tokenLockManagerOwner = await manager.owner()
+    const { deployer } = await hre.getNamedAccounts()
+    if (tokenLockManagerOwner !== deployer) {
+      logger.error('Only the owner can transfer ownership')
+      process.exit(1)
+    }
+
+    logger.info(`Manager address: ${manager.address}}`)
+    logger.info(`Current owner: ${tokenLockManagerOwner}`)
+    logger.info(`New owner: ${taskArgs.owner}`)
+
+    if (!(await askConfirm())) {
+      logger.log('Cancelled')
+      process.exit(1)
+    }
+
+    // Transfer ownership
+    await manager.transferOwnership(taskArgs.owner)
+  })


### PR DESCRIPTION
**Changes**
This PR allows deploying the same contract multiple times instead of overwriting the previous deployment.

When running the deploy script a prompt will ask for the desired deployment name:
- Inputing an existing deployment name will default to the current behavior
- Inputing a new deployment name will prompt the script to deploy the contract to a new address/deployment.

As a result of this change, several tasks now require specifying the deployment name to disambiguate in case there are multiple deployments (see below). 

**Example: new deployment**
```
tomi@ceres:/U/t/g/th/token-distribution (main) ✗ npx hardhat deploy --tags manager --network goerli
Nothing to compile
No need to generate any newer typings.
? What is the GRT token address? 0x5c946740441C12510a167B447B7dE565C20b9E3C
ℹ Deploying GraphTokenLockWallet master copy...                                                                                    16:20:02
? Save deployment as? test
deploying "test" (tx: 0xd27ffcc10b3cf2c9451102948e64163543af5e5491a16521773a460fc14de1cd)...: deployed at 0x03D26aAe335526ebF3CC1509362533218
cC4Cd6c with 3482943 gas
ℹ Deploying GraphTokenLockManager...                                                                                               16:20:30
? Save deployment as? testtt
deploying "testtt" (tx: 0xb6e533bbd5022c86ca31a76e958e4f43427438f7f2b456b04f36a272a0b582d6)...: deployed at 0x602821F3563c22Aa98AB48BB6caAb6e
1c873935e with 3166292 gas
? Do you want to fund the manager? No
```

**Sample: check manager balance for `GraphTokenLockManager` deployment**
```
tomi@ceres:/U/t/g/th/token-distribution (main) ✗ npx hardhat manager-balance  --network goerli
                                                                                                                                   16:36:40
  Wallet: address=0xBc7f4d3a85B820fDB1058FD93073Eb6bc9AAF59b chain=5 nonce=155 balance=0.178089136334598915
  Gas settings: gas=auto gasPrice=auto

ℹ Using:                                                                                                                           16:36:40
> GraphToken: 0x5c946740441C12510a167B447B7dE565C20b9E3C                                                                           16:36:40
> GraphTokenLockMasterCopy: 0xbBCeB991e59a4E53DfDbD4a4B1843de1830017B3                                                             16:36:41
> GraphTokenLockManager: 0x9a7a54e86560f4304d8862Ea00F45D1090c59ac8 owner: 0xf1135bFF22512FF2A585b8d4489426CE660f204c              16:36:41
Current Manager balance is  0.0                                                                                                    16:36:41
```

**Sample: check manager balance for `testtt` deployment**

```
tomi@ceres:/U/t/g/th/token-distribution (main) ✗ npx hardhat manager-balance  --network goerli --manager-name testtt
                                                                                                                                   16:38:03
  Wallet: address=0xBc7f4d3a85B820fDB1058FD93073Eb6bc9AAF59b chain=5 nonce=155 balance=0.178089136334598915
  Gas settings: gas=auto gasPrice=auto

ℹ Using:                                                                                                                           16:38:04
> GraphToken: 0x5c946740441C12510a167B447B7dE565C20b9E3C                                                                           16:38:04
> GraphTokenLockMasterCopy: 0x03D26aAe335526ebF3CC1509362533218cC4Cd6c                                                             16:38:04
> GraphTokenLockManager: 0x602821F3563c22Aa98AB48BB6caAb6e1c873935e owner: 0xBc7f4d3a85B820fDB1058FD93073Eb6bc9AAF59b              16:38:04
Current Manager balance is  0.0
```


Signed-off-by: Tomás Migone <tomas@edgeandnode.com>