### PR TITLE
fix: make MinimalProxyFactory backwards compatible

### DIFF
--- a/contracts/MinimalProxyFactory.sol
+++ b/contracts/MinimalProxyFactory.sol
@@ -14,6 +14,21 @@ contract MinimalProxyFactory {
     /// @dev Emitted when a new proxy is created
     event ProxyCreated(address indexed proxy);
 
+
+    /**
+     * @notice Gets the deterministic CREATE2 address for MinimalProxy with a particular implementation
+     * @dev Uses address(this) as deployer to compute the address. Only for backwards compatibility.
+     * @param _salt Bytes32 salt to use for CREATE2
+     * @param _implementation Address of the proxy target implementation
+     * @return Address of the counterfactual MinimalProxy
+     */
+    function getDeploymentAddress(
+        bytes32 _salt,
+        address _implementation
+    ) public view returns (address) {
+        return Create2.computeAddress(_salt, keccak256(_getContractCreationCode(_implementation)), address(this));
+    }
+
     /**
      * @notice Gets the deterministic CREATE2 address for MinimalProxy with a particular implementation
      * @param _salt Bytes32 salt to use for CREATE2

--- a/contracts/MinimalProxyFactory.sol
+++ b/contracts/MinimalProxyFactory.sol
@@ -26,7 +26,7 @@ contract MinimalProxyFactory {
         bytes32 _salt,
         address _implementation
     ) public view returns (address) {
-        return Create2.computeAddress(_salt, keccak256(_getContractCreationCode(_implementation)), address(this));
+        return getDeploymentAddress(_salt, _implementation, address(this));
     }
 
     /**

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -225,7 +225,7 @@ const getDeployContractAddresses = async (entries: TokenLockConfigEntry[], manag
     // There are two type of managers
     let contractAddress = ''
     try {
-      contractAddress = await manager['getDeploymentAddress(bytes32,address, address)'](
+      contractAddress = await manager['getDeploymentAddress(bytes32,address,address)'](
         entry.salt,
         masterCopy,
         manager.address,

--- a/ops/create.ts
+++ b/ops/create.ts
@@ -222,7 +222,18 @@ const getContractFactory = async (hre: HardhatRuntimeEnvironment, name: string) 
 const getDeployContractAddresses = async (entries: TokenLockConfigEntry[], manager: Contract) => {
   const masterCopy = await manager.masterCopy()
   for (const entry of entries) {
-    const contractAddress = await manager.getDeploymentAddress(entry.salt, masterCopy, manager.address)
+    // There are two type of managers
+    let contractAddress = ''
+    try {
+      contractAddress = await manager['getDeploymentAddress(bytes32,address, address)'](
+        entry.salt,
+        masterCopy,
+        manager.address,
+      )
+    } catch (error) {
+      contractAddress = await manager['getDeploymentAddress(bytes32,address)'](entry.salt, masterCopy)
+    }
+
     const deployEntry = { ...entry, salt: entry.salt, txHash: '', contractAddress }
     logger.log(prettyConfigEntry(deployEntry))
   }

--- a/test/l1TokenLockTransferTool.test.ts
+++ b/test/l1TokenLockTransferTool.test.ts
@@ -282,10 +282,19 @@ describe('L1GraphTokenLockTransferTool', () => {
       // WalletMock constructor args are: target, token, manager, isInitialized, isAccepted
       await deployments.deploy('WalletMock', {
         from: deployer.address,
-        args: [transferTool.address, '0x5c946740441C12510a167B447B7dE565C20b9E3C', tokenLockManager.address, true, true],
+        args: [
+          transferTool.address,
+          '0x5c946740441C12510a167B447B7dE565C20b9E3C',
+          tokenLockManager.address,
+          true,
+          true,
+        ],
       })
       const wrongTokenWallet = await getContract('WalletMock')
-      const walletAsTransferTool = L1GraphTokenLockTransferTool__factory.connect(wrongTokenWallet.address, deployer.signer)
+      const walletAsTransferTool = L1GraphTokenLockTransferTool__factory.connect(
+        wrongTokenWallet.address,
+        deployer.signer,
+      )
 
       const tx = walletAsTransferTool
         .connect(beneficiary.signer)
@@ -383,7 +392,7 @@ describe('L1GraphTokenLockTransferTool', () => {
           ],
         ],
       )
-      const expectedL2Address = await transferTool.getDeploymentAddress(
+      const expectedL2Address = await transferTool['getDeploymentAddress(bytes32,address,address)'](
         keccak256(expectedWalletData),
         l2LockImplementationMock.address,
         l2ManagerMock.address,
@@ -413,11 +422,9 @@ describe('L1GraphTokenLockTransferTool', () => {
         )
       // Check that the right amount of ETH has been pulled from the token lock's account
       await expect(tx)
-          .emit(transferTool, 'ETHPulled')
-          .withArgs(tokenLock.address, maxGas.mul(gasPrice).add(maxSubmissionCost))
-      await expect(tx)
-          .emit(transferTool, 'L2BeneficiarySet')
-          .withArgs(tokenLock.address, l2Beneficiary.address)
+        .emit(transferTool, 'ETHPulled')
+        .withArgs(tokenLock.address, maxGas.mul(gasPrice).add(maxSubmissionCost))
+      await expect(tx).emit(transferTool, 'L2BeneficiarySet').withArgs(tokenLock.address, l2Beneficiary.address)
       // Check the events emitted from the mock gateway
       await expect(tx)
         .emit(gateway, 'FakeTxToL2')
@@ -442,7 +449,7 @@ describe('L1GraphTokenLockTransferTool', () => {
           ],
         ],
       )
-      const expectedL2Address = await transferTool.getDeploymentAddress(
+      const expectedL2Address = await transferTool['getDeploymentAddress(bytes32,address,address)'](
         keccak256(expectedWalletData),
         l2LockImplementationMock.address,
         l2ManagerMock.address,
@@ -474,8 +481,7 @@ describe('L1GraphTokenLockTransferTool', () => {
           l2ManagerMock.address,
           amountToSend,
         )
-      await expect(tx)
-        .not.emit(transferTool, 'L2BeneficiarySet')
+      await expect(tx).not.emit(transferTool, 'L2BeneficiarySet')
       // Check the events emitted from the mock gateway
       await expect(tx)
         .emit(gateway, 'FakeTxToL2')
@@ -506,7 +512,7 @@ describe('L1GraphTokenLockTransferTool', () => {
           ],
         ],
       )
-      const expectedL2Address = await transferTool.getDeploymentAddress(
+      const expectedL2Address = await transferTool['getDeploymentAddress(bytes32,address,address)'](
         keccak256(expectedWalletData),
         l2LockImplementationMock.address,
         l2ManagerMock.address,

--- a/test/l2TokenLockManager.test.ts
+++ b/test/l2TokenLockManager.test.ts
@@ -215,7 +215,7 @@ describe('L2GraphTokenLockManager', () => {
         endTime: initArgs.endTime,
       }
 
-      const expectedL2Address = await tokenLockManager.getDeploymentAddress(
+      const expectedL2Address = await tokenLockManager['getDeploymentAddress(bytes32,address,address)'](
         keccak256(data),
         tokenLockImplementation.address,
         tokenLockManager.address,
@@ -297,7 +297,7 @@ describe('L2GraphTokenLockManager', () => {
         endTime: initArgs.endTime,
       }
 
-      const expectedL2Address = await tokenLockManager.getDeploymentAddress(
+      const expectedL2Address = await tokenLockManager['getDeploymentAddress(bytes32,address,address)'](
         keccak256(data),
         tokenLockImplementation.address,
         tokenLockManager.address,
@@ -365,7 +365,7 @@ describe('L2GraphTokenLockManager', () => {
         ],
       )
 
-      const expectedL2Address = await tokenLockManager.getDeploymentAddress(
+      const expectedL2Address = await tokenLockManager['getDeploymentAddress(bytes32,address,address)'](
         keccak256(data),
         tokenLockImplementation.address,
         tokenLockManager.address,
@@ -375,7 +375,9 @@ describe('L2GraphTokenLockManager', () => {
       const transferredAmount = initArgs.managedAmount.sub(toGRT('100000'))
 
       // Call onTokenTransfer from the gateway:
-      await tokenLockManager.connect(gateway.signer).onTokenTransfer(l1TransferToolMock.address, transferredAmount, data)
+      await tokenLockManager
+        .connect(gateway.signer)
+        .onTokenTransfer(l1TransferToolMock.address, transferredAmount, data)
 
       // Check that the token lock wallet was created with the correct parameters
       const tokenLock = (await ethers.getContractAt(
@@ -417,7 +419,7 @@ describe('L2GraphTokenLockManager', () => {
         ],
       )
 
-      const expectedL2Address = await tokenLockManager.getDeploymentAddress(
+      const expectedL2Address = await tokenLockManager['getDeploymentAddress(bytes32,address,address)'](
         keccak256(data),
         tokenLockImplementation.address,
         tokenLockManager.address,
@@ -427,7 +429,9 @@ describe('L2GraphTokenLockManager', () => {
       const transferredAmount = initArgs.managedAmount.sub(toGRT('100000'))
 
       // Call onTokenTransfer from the gateway:
-      await tokenLockManager.connect(gateway.signer).onTokenTransfer(l1TransferToolMock.address, transferredAmount, data)
+      await tokenLockManager
+        .connect(gateway.signer)
+        .onTokenTransfer(l1TransferToolMock.address, transferredAmount, data)
 
       // Check that the token lock wallet was created with the correct parameters
       const tokenLock = (await ethers.getContractAt(

--- a/test/l2TokenLockTransferTool.test.ts
+++ b/test/l2TokenLockTransferTool.test.ts
@@ -143,7 +143,7 @@ describe('L2GraphTokenLockTransferTool', () => {
 
     await expect(tx).emit(tokenLockManager, 'TokenLockCreatedFromL1')
 
-    const expectedL2Address = await tokenLockManager.getDeploymentAddress(
+    const expectedL2Address = await tokenLockManager['getDeploymentAddress(bytes32,address,address)'](
       keccak256(data),
       tokenLockImplementation.address,
       tokenLockManager.address,


### PR DESCRIPTION
This PR adds back the old function signature for `function getDeploymentAddress(bytes32 _salt, address _implementation)` to `MinimalProxyFactory` contract. This is to ensure the tooling can handle both old and new managers when deploying new vesting contracts.

We could also add a stitched ABI and avoid re-adding the old code.